### PR TITLE
add two more methods to the monotonic section

### DIFF
--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1280,9 +1280,14 @@ Replace Left-Most Random Bits with Increased Clock Precision (Method 4):
   as the most significant (left-most) portion of the random section of the UUID.
   This works for any desired bit length that fits into a UUID and applications
   can decide the appropriate length based on available clock precision and desired
-  random bits.  This technique can also be used in conjunction with one of
-  the other methods, where this additional time precision would immediatley
-  follow the timestamp and then any bits used as clock sequence would follow next.  
+  random bits. The main benefit to encoding additional timestamp precision
+  is that it utilizes additional time precision already available in the system clock
+  to provide values that are more likely to be unique, and thus may simplify
+  certain implementations. This technique can also be used in conjunction with one
+  of the other methods, where this additional time precision would immediatley
+  follow the timestamp and then if any bits are to be used as clock sequence
+  they would follow next.
+  
 
 The following sub-topics cover topics related solely with creating reliable
 fixed-length dedicated counters:

--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1283,7 +1283,7 @@ Replace Left-Most Random Bits with Increased Clock Precision (Method 4):
   which is sorts monotonically based on time. Each increasing fractional
   value will result in an increasing bit field value, to the
   precision available with these bits.
-  
+
   For example, let's assume a system timestamp of 1 Jan 2023 12:34:56.1234567.
   Taking the precision greater than 1ms gives us a value of 0.4567, as a
   fraction of a millisecond.  If we wish to encode this as 12 bits, we can

--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1287,7 +1287,6 @@ Replace Left-Most Random Bits with Increased Clock Precision (Method 4):
   of the other methods, where this additional time precision would immediatley
   follow the timestamp and then if any bits are to be used as clock sequence
   they would follow next.
-  
 
 The following sub-topics cover topics related solely with creating reliable
 fixed-length dedicated counters:


### PR DESCRIPTION
After reading through everything again, while the monotonic/counter section works as it stands now, I think it would greatly benefit from two other specific suggested methods for achieving monotonicity.

The first I think is beneficial because it is trivial to implement (just keep generating random values until you get one that is greater than the last), and implementors prioritizing simplicity would benefit from it.

And the second brings back a concept that I originally proposed in the initial draft for UUID v7 (using bits in the UUID that immediately follow the timestamp to encode more timestamp precision in a way that is time ordered), but later removed because it was often misunderstood.  However, I think the key benefit to this approach (just using the additional precision available in the system clock for what it is meant for) still exists and makes sense, and having it here as an optional feature so implementations are not required to understand and use it if they don't need to - I believe that tradeoff makes a lot of sense.  I tried to keep it super simple by just giving an example of how to use it, and people can infer the underlying math/theory or not as needed.