### PR TITLE
Change rounding mode of Method 4 Section 6.2

### DIFF
--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -821,7 +821,7 @@ md5_low:
 The version 4 UUID is meant for generating UUIDs from truly-random or
 pseudo-random numbers.
 
-An implementation may generate 128 bits of random random data which is
+An implementation may generate 128 bits of random data which is
 used to fill out the UUID fields in {{uuidv4fields}}. The UUID version
 and variant then replace the respective bits as defined by {{version_field}}
 and {{variant_field}},

--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1002,7 +1002,7 @@ UUIDv1 implementation.
 
 UUID version 7 features a time-ordered value field derived from the widely
 implemented and well known Unix Epoch timestamp source, the number of milliseconds
-seconds since midnight 1 Jan 1970 UTC, leap seconds excluded.
+since midnight 1 Jan 1970 UTC, leap seconds excluded.
 UUID version 7 also has improved entropy characteristics over versions 1 or 6.
 
 Implementations SHOULD utilize UUID version 7 instead of UUID version 1 and 6 if

--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1298,10 +1298,10 @@ Replace Left-Most Random Bits with Increased Clock Precision (Method 4):
 
   To calculate this value, start with the portion of the timestamp
   expressed as a fraction of clock's tick value (fraction of a millisecond
-  for UUIDv7).  Compute the maximum value that can be represented in
-  the available bit space, 4095 for the UUIDv7 rand_a field.
+  for UUIDv7).  Compute the count of possible values that can be represented in
+  the available bit space, 4096 for the UUIDv7 rand_a field.
   Using floating point math, multiply this fraction of a millisecond
-  value by 4095 and round to an integer result to arrive at a number
+  value by 4096 and round down (toward zero) to an integer result to arrive at a number
   between 0 and the maximum allowed for the indicated bits
   which is sorts monotonically based on time. Each increasing fractional
   value will result in an increasing bit field value, to the
@@ -1310,8 +1310,8 @@ Replace Left-Most Random Bits with Increased Clock Precision (Method 4):
   For example, let's assume a system timestamp of 1 Jan 2023 12:34:56.1234567.
   Taking the precision greater than 1ms gives us a value of 0.4567, as a
   fraction of a millisecond.  If we wish to encode this as 12 bits, we can
-  take the maximum value that fits in those bits (4095, or 2 to the 12th power minus 1)
-  and multiply it by our millisecond fraction value of 0.4567 and round the result to
+  take the count of possible values that fit in those bits (4096, or 2 to the 12th power)
+  and multiply it by our millisecond fraction value of 0.4567 and truncate the result to
   an integer, which gives an integer value of 1870. Expressed as hexadecimal it is
   0x74E, or the binary bits 011101001110.  One can then use those 12 bits
   as the most significant (left-most) portion of the random section of the UUID


### PR DESCRIPTION
Changes the rounding mode demonstrated in Replace Left-Most Random Bits with Increased Clock Precision (Method 4) from ties-to-nearest to round-down-toward-zero.

https://github.com/ietf-wg-uuidrev/rfc4122bis/issues/86#issuecomment-1548940686