### PR TITLE
Omit UUIDv6 in UUIDs that Do Not Identify the Host

### DIFF
--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1666,7 +1666,7 @@ CSPRNG ensures the best of {{collision_resistance}} and {{Security}} are present
 Further advice on generating cryptographic-quality random numbers can be found in {{RFC4086}} and in {{RANDOM}}.
 
 ## UUIDs That Do Not Identify the Host {#unidentifiable}
-This section describes how to generate a UUIDv1 or UUIDv6 value if an IEEE
+This section describes how to generate a UUIDv1 value if an IEEE
 802 address is not available, or its use is not desired.
 
 Implementations SHOULD obtain a 47-bit cryptographic-quality random


### PR DESCRIPTION
Could be controversial, but I think we can omit UUIDv6 from the UUIDs that Do Not Identify the Host section. The spec is clear without the name of UUIDv6 here that UUIDv6 MAY follow this section, but this section remains mostly for backward compatibility and is not a primary path for UUIDv6 creation. If read alone, this section could read that UUIDv6 implementations MUST set the unicast/multicast bit to one if an IEEE 802 address is not available. This could be a source of confusion for readers.
