### PR TITLE
Fix errata  6225 (again); GitHub issue #117

### DIFF
--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1840,7 +1840,7 @@ was also invaluable in achieving coordination with ISO/IEC.
 # Some Name Space IDs {#namespaces}
 
 This appendix lists the name space IDs for some potentially interesting name spaces such those for
-fully-qualified domain names (DNS), uniform resource locators (URLs), Object Identifiers (OID) in dot-notation without leading dot, and X.500 distinguished names (DNs) in distinguished encoding rule (DER) or text format.
+fully-qualified domain names (DNS), uniform resource locators (URLs), Object Identifiers (OIDs) in dot-notation without leading dot, and X.500 distinguished names (DNs) in distinguished encoding rule (DER) or text format.
 
 ~~~~ code
 NameSpace_DNS  = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"

--- a/draft-ietf-uuidrev-rfc4122bis.md
+++ b/draft-ietf-uuidrev-rfc4122bis.md
@@ -1840,7 +1840,7 @@ was also invaluable in achieving coordination with ISO/IEC.
 # Some Name Space IDs {#namespaces}
 
 This appendix lists the name space IDs for some potentially interesting name spaces such those for
-fully-qualified domain names (DNS), uniform resource locators (URLs), ISO OIDs, and X.500 distinguished names (DNs) in distinguished encoding rule (DER) or text format.
+fully-qualified domain names (DNS), uniform resource locators (URLs), Object Identifiers (OID) in dot-notation without leading dot, and X.500 distinguished names (DNs) in distinguished encoding rule (DER) or text format.
 
 ~~~~ code
 NameSpace_DNS  = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"


### PR DESCRIPTION
In 2020, I reported [errata 6225 for RFC4122](https://www.rfc-editor.org/errata/eid6225)

The errata is mentioned in the changelog of "draft-00", so I guess it was fixed. Thank you for changing this.

However, there is another reference where it says "ISO OID", in Appendix A.  It should be called "Object Identifier (OID)".

I also mentioned in Errata 6225, that I think it would be important to define how the OID should be defined, so I think it should mention in parentheses "In dot-notation without leading dot" (e.g. 2.999).
